### PR TITLE
Preemptively convert `n` to double

### DIFF
--- a/R/count.R
+++ b/R/count.R
@@ -275,6 +275,7 @@ process_count_n <- function(x) {
       # Group by variables including target variables and count them
       group_by(!!treat_var, !!!by, !!!target_var, !!!cols) %>%
       tally(name = "n") %>%
+      mutate(n = as.double(n)) %>%
       ungroup()
 
     # If there is a missing_count_string, but its not in the dataset


### PR DESCRIPTION
We are updating `tidyr::replace_na()` to utilize the vctrs package, and that results in slightly stricter / more correct type conversions. See https://github.com/tidyverse/tidyr/pull/1219

We noticed in revdeps that this package broke. An easy way to see this is by installing the PR mentioned above and running the tests. You should get 12 failures that look like:

``` r
Failure (test-count.R:214:3): Count layers are processed as expected
c1$numeric_data$n has type 'integer', not 'double'.




Failure (test-count.R:444:3): Total rows and missing counts are displayed correctly(0.1.5 Updates)
Results have changed from known value recorded in 'count_t7'.

old[2:7] vs new[2:7]
  "    var1_3 = c(\" 2 (13.3)\", \"12 (80.0)\", \" 1\", \"   15 [100.0]\""
  "    ), var1_4 = c(\" 4 (33.3)\", \" 0 ( 0.0)\", \" 8\", \"   12 [100.0]\""
  "    ), var1_5 = c(\" 1 (20.0)\", \" 2 (40.0)\", \" 2\", \"    5 [100.0]\""
- "    ), ord_layer_index = c(1L, 1L, 1L, 1L), ord_layer_1 = c(4, "
+ "    ), ord_layer_index = c(1L, 1L, 1L, 1L), ord_layer_1 = c(4L, "
- "    0, 8, -6795)), row.names = c(NA, -4L), class = c(\"tbl_df\", "
+ "    0L, 8L, -6795L)), row.names = c(NA, -4L), class = c(\"tbl_df\", "
  "\"tbl\", \"data.frame\"))"
```

<sup>Created on 2021-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The problem boils down to the fact that a call to `tally()` was creating an _integer_ column named `n`, but then you had many calls to either `complete()` or `replace_na()` that utilized either `fill = list(n = 0)` or `replace = list(n = 0)` respectively. This used a _double_ `0` as the replacement value, and in the CRAN version of tidyr that promotes the entire `n` column from an integer vector to a double vector.

This is no longer allowed, and instead `0` is converted to an integer (`0L`) and `n` is kept as an integer column. This is why the failures are like `$n has type 'integer', not 'double'`.

Since you seem to use `list(n = 0)` in _many_ places, I decided the easiest solution is just to convert the `tally()` result to double immediately. This has the benefit that it works on both CRAN and dev tidyr, so you don't have to wait on us to send in a patch.

We would greatly appreciate if you could merge this PR and submit a patch release of your package to CRAN so we can send tidyr in!