### PR TITLE
Ungroup before completing

### DIFF
--- a/R/shift.R
+++ b/R/shift.R
@@ -169,6 +169,7 @@ process_shift_denoms <- function(x) {
       filter(!!denom_where) %>%
       group_by(!!!unname(target_var), !!treat_var, !!!by, !!!cols) %>%
       summarize(n = n()) %>%
+      ungroup() %>%
       complete(!!!unname(target_var), !!treat_var, !!!by, !!!cols) %>%
       # The rows will duplicate for some reason so this removes that
       distinct() %>%


### PR DESCRIPTION
Hi @elimillera I found another small issue.

We are planning on releasing tidyr 1.2.0 towards the end of this month.

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run your tests, you should get something like:

``` r
Error (test-shift.R:34:3): group_shift layers can be built without warnings/errors
<dplyr_error/rlang_error/error/condition>
Error: Problem with `summarise()` input `..1`.
ℹ `..1 = complete(data = dplyr::cur_data(), ..., fill = fill, explicit = explicit)`.
x object 'cyl' not found
ℹ The error occurred in group 1: cyl = 4, cyl2 = 14.
Backtrace:
  1. testthat::expect_silent(build(t1)) test-shift.R:34:2
 35. base::.handleSimpleError(...)
 36. dplyr:::h(simpleError(msg, call))
```

The problem comes down to the fact that you were trying to call `complete()` with a grouped data frame, and you were trying to complete on the group column. This is actually not well defined, as `complete()` completes "within" each group, so you really shouldn't have access to the group variables.  The previous behavior was problematic in many cases (see https://github.com/tidyverse/tidyr/issues/396 and https://github.com/tidyverse/tidyr/issues/966), so we've made a fix to ensure that `complete()` works correctly with grouped data frames in all cases. This fix comes with the restriction that now you can't specify the group variables in the call to `complete()`.

It looks like you really want to ungroup, then complete, so that is what this PR does. Note that the need to call `distinct()` may have been because of some of the previous problematic behavior with `complete()` so it may not be necessary to call that now, but I didn't check.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!