### PR TITLE
Fix partially provided decimal/int caps

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -348,6 +348,10 @@ set_format_strings.desc_layer <- function(e, ..., cap=getOption('tplyr.precision
   # Identify if auto precision is needed
   need_prec_table <- any(map_lgl(format_strings, ~ .x$auto_precision))
 
+  # Fill in defaults if cap hasn't fully been provided
+  if (!('int' %in% names(cap))) cap['int'] <- getOption('tplyr.precision_cap')['int']
+  if (!('dec' %in% names(cap))) cap['dec'] <- getOption('tplyr.precision_cap')['dec']
+
   env_bind(e,
            format_strings = format_strings,
            summary_vars = vars(!!!summary_vars),

--- a/tests/testthat/_snaps/precision.md
+++ b/tests/testthat/_snaps/precision.md
@@ -1,0 +1,9 @@
+# Partially provided decimal precision caps populate correctly
+
+    # A tibble: 3 x 3
+      var1_Placebo     `var1_Xanomeline High Dose` `var1_Xanomeline Low Dose`
+      <chr>            <chr>                       <chr>                     
+    1 288.4 ( 70.6)    295.1 ( 79.5)               295.3 ( 72.2)             
+    2 288.369 (70.648) 295.061 (79.479)            295.314 (72.151)          
+    3 288.4 (70.6)     295.1 (79.5)                295.3 (72.2)              
+

--- a/tests/testthat/test-precision.R
+++ b/tests/testthat/test-precision.R
@@ -117,3 +117,25 @@ test_that('Caps work correctly', {
 
 })
 
+test_that("Partially provided decimal precision caps populate correctly", {
+  t <- tplyr_table(adlb, TRTA, where = PARAMCD == 'URATE') %>%
+    add_layer(
+      group_desc(AVAL) %>%
+        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(dec = 1))
+    ) %>%
+    add_layer(
+      group_desc(AVAL) %>%
+        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(int = 1))
+    ) %>%
+    add_layer(
+      group_desc(AVAL) %>%
+        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(int = 1, dec = 1))
+    )
+
+  # In bug #20 this caused an error so expect build to complete correctly
+  expect_silent(d <- build(t))
+
+  # Manually verified these results look appropriate
+  expect_snapshot_output(print(d %>% select(starts_with('var1'))))
+})
+


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

This resolves #20. The following tests have been added:
```r
test_that("Partially provided decimal precision caps populate correctly", {
  t <- tplyr_table(adlb, TRTA, where = PARAMCD == 'URATE') %>%
    add_layer(
      group_desc(AVAL) %>%
        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(dec = 1))
    ) %>%
    add_layer(
      group_desc(AVAL) %>%
        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(int = 1))
    ) %>%
    add_layer(
      group_desc(AVAL) %>%
        set_format_strings("Mean (SD)" = f_str("a.a (a.a)", mean, sd), cap = c(int = 1, dec = 1))
    )

  # In bug #20 this caused an error so expect build to complete correctly
  expect_silent(d <- build(t))

  # Manually verified these results look appropriate
  expect_snapshot_output(print(d %>% select(starts_with('var1'))))
})
```