### PR TITLE
Execute Issue 66

### DIFF
--- a/R/layer_templates.R
+++ b/R/layer_templates.R
@@ -23,6 +23,7 @@ new_layer_template <- function(name, template) {
   )
 }
 
+#' @export
 use_template <- function(name) {
   template <- getOption("tplyr.layer_templates")[[name]]
 

--- a/R/layer_templates.R
+++ b/R/layer_templates.R
@@ -1,0 +1,35 @@
+#' export
+new_layer_template <- function(name, template) {
+  template <- enexpr(template)
+
+  if (name %in% objects("package:Tplyr")) {
+    stop("Template name cannot be a name already present in Tplyr's namespace")
+  }
+  # Make sure that the tempalte is valid
+  modify_nested_call(template, examine_only = TRUE)
+
+  # Turn the template into a function, with class to mark as a template
+  func <-structure(
+    eval(str2lang(paste0(c("function(...) {", template, "}"), collapse="\n"))),
+    class = c("tplyr_layer_template", "function")
+  )
+
+  add_func <- list(func)
+  names(add_func) <- name
+
+  # Insert the function into the Tplyr namespace
+  options(
+    tplyr.layer_templates = append(getOption("tplyr.layer_templates"), add_func)
+  )
+}
+
+use_template <- function(name) {
+  template <- getOption("tplyr.layer_templates")[[name]]
+
+  if (!inherits(template, "tplyr_layer_template")) {
+    stop("Invalid template - templates must be created using `new_layer_template()`")
+  }
+
+  template
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -16,14 +16,14 @@ modify_nested_call <- function(c, examine_only=FALSE, ...) {
 
   # Only allow the user to use `Tplyr` functions
   assert_that(
-    call_name(c) %in% allowable_calls,
+    get_call_name(c) %in% allowable_calls,
     msg = "Functions called within `add_layer` must be part of `Tplyr`"
     )
 
   # Process the magrittr pipe
-  if (call_name(c) == "%>%") {
+  if (get_call_name(c) == "%>%") {
     # Only allow the user to use `Tplyr` functions on both sides of the pipe
-    assert_that(all(map_chr(call_args(c), call_name) %in% allowable_calls),
+    assert_that(all(map_chr(call_args(c), get_call_name) %in% allowable_calls),
                 msg="Functions called within `add_layer` must be part of `Tplyr`")
 
     # Recursively extract the left side of the magrittr call to work your way up
@@ -36,7 +36,7 @@ modify_nested_call <- function(c, examine_only=FALSE, ...) {
     }
   }
   # Process the 'native' pipe (arguments logically insert as first parameter)
-  else if (!str_starts(call_name(c), "group_[cds]")) {
+  else if (!str_starts(get_call_name(c), "group_[cds]|use_template")) {
 
     # Standardize the call to get argument names and pull out the literal first argument
     # Save the call to a new variable in the process
@@ -60,6 +60,25 @@ modify_nested_call <- function(c, examine_only=FALSE, ...) {
     c <- call_modify(.call=c, ...)
   }
 
+}
+
+#' Get call name from a call or quosure
+#'
+#' When using templates, the top call comes in as a quosure, so handle that
+#' capture
+#'
+#' @param c call or quosure
+#'
+#' @return character string
+#' @noRd
+get_call_name <- function(c) {
+  cname <- call_name(c)
+
+  # Get call name out of a quosure
+  if (is.null(cname)) {
+    cname <- str_extract(as_label(c), "[\\w]+(?=\\()")
+  }
+  cname
 }
 
 #' Find depth of a layer object

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,7 +9,7 @@
 #' @return The original call object with
 #'
 #' @noRd
-modify_nested_call <- function(c, ...) {
+modify_nested_call <- function(c, examine_only=FALSE, ...) {
 
   # Get exports from Tplyr
   allowable_calls = objects("package:Tplyr")
@@ -28,10 +28,12 @@ modify_nested_call <- function(c, ...) {
 
     # Recursively extract the left side of the magrittr call to work your way up
     e <- call_standardise(c)
-    c <- modify_nested_call(call_args(e)$lhs, ...)
-    # Modify the magittr call by inserting the call retrieved from recursive command back in
-    c <- call_modify(e, lhs=c)
-    c
+    c <- modify_nested_call(call_args(e)$lhs, examine_only, ...)
+    if (!examine_only) {
+      # Modify the magittr call by inserting the call retrieved from recursive command back in
+      c <- call_modify(e, lhs=c)
+      c
+    }
   }
   # Process the 'native' pipe (arguments logically insert as first parameter)
   else if (!str_starts(call_name(c), "group_[cds]")) {
@@ -44,14 +46,17 @@ modify_nested_call <- function(c, ...) {
     # Send the first parameter back down recursively through modify_nested_call and
     # save it back to the arguments list
     c <- modify_nested_call(call_args(c)[[1]], ...)
-    args[[1]] <- c
 
-    # Modify the standardized call with the modified first parameter and send it up
-    c <- call_modify(e, !!!args)
-    c
+    if (!examine_only) {
+      args[[1]] <- c
+
+      # Modify the standardized call with the modified first parameter and send it up
+      c <- call_modify(e, !!!args)
+      c
+    }
   }
   # If the call is not from magrittr or the pipe, then modify the contents and return the call
-  else  {
+  else if (!examine_only) {
     c <- call_modify(.call=c, ...)
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -159,7 +159,10 @@ tplyr_default_options <- list(
   tplyr.quantile_type = 7,
 
   # Rounding option default
-  tplyr.IBMRounding = FALSE
+  tplyr.IBMRounding = FALSE,
+
+  # Layer templates
+  tplyr.layer_templates = list()
 )
 
 # Carry out process on load ----


### PR DESCRIPTION
# Layer Templates

I'll build out this PR, but wanted to get this in draft form - this introduces a framework for building full layer templates. 

Here's some POC code:

```r
# Templates are saved into the option tplyr.layer_template 
# and and referencable by name
# They're classed becaused templates are validated just like
# layers called within a table directly
new_layer_template("my_template",
  group_count(...) %>% 
    set_format_strings(f_str("xx (xx.x%)", n, pct))
 )

tplyr_table(adae, TRTA) %>% 
  add_layer(
    # Call the layer from a template
    use_template('my_template')(AEBODSYS, by="Some by variable text")
  ) %>% 
  build()

tplyr_table(adae, TRTA) %>% 
  add_layer(
    # Call the layer from a template
    use_template('my_template')(AEBODSYS, by="Some by variable text") %>% 
      # Template layers are still extendable, just like a normal layer
      add_total_row()
  ) %>% 
  build()
```
