### PR TITLE
Fixes for wrong count denoms

### DIFF
--- a/R/count.R
+++ b/R/count.R
@@ -178,43 +178,6 @@ process_single_count_target <- function(x) {
   }, envir = x)
 }
 
-#' This function resets the variables for a nested layer after it was built
-#' @noRd
-refresh_nest <- function(x) {
-  env_bind(x, by = env_get(x, "by_saved"))
-  env_bind(x, target_var = env_get(x, "target_var_saved"))
-}
-
-#' This function is meant to remove the values of an inner layer that don't
-#' appear in the target data
-#' @noRd
-filter_nested_inner_layer <- function(.group, target, outer_name, inner_name, indentation) {
-
-  # Is outer variable text? If it is don't filter on it
-  text_outer <- !quo_is_symbol(outer_name)
-  outer_name <- as_name(outer_name)
-  inner_name <- as_name(inner_name)
-
-  if (text_outer) {
-    target_inner_values <- target %>%
-      select(any_of(inner_name)) %>%
-      unlist() %>%
-      paste0(indentation, .)
-  } else {
-    current_outer_value <- unique(.group[, outer_name])[[1]]
-
-    target_inner_values <- target %>%
-      filter(!!sym(outer_name) == current_outer_value) %>%
-      select(any_of(inner_name)) %>%
-      unlist() %>%
-      paste0(indentation, .)
-  }
-
-  .group %>%
-    filter(summary_var %in% target_inner_values)
-
-}
-
 #' Process the n count data and put into summary_stat
 #'
 #' @param x Count layer

--- a/R/count.R
+++ b/R/count.R
@@ -268,9 +268,8 @@ process_count_n <- function(x) {
       # Change the treat_var and first target_var to characters to resolve any
       # issues if there are total rows and the original column is numeric
       mutate(!!treat_var := as.character(!!treat_var)) %>%
-      mutate(!!as_name(target_var[[1]]) := as.character(!!target_var[[1]])) %>% ##
+      mutate(!!as_name(target_var[[1]]) := as.character(!!target_var[[1]])) %>%
       group_by(!!!denoms_by_) %>%
-      do(get_denom_total(., denoms_by_, denoms_df, "distinct_n")) %>%
       ungroup()
 
     rm(denoms_by_)
@@ -717,9 +716,9 @@ process_count_denoms <- function(x) {
     names(by_join) <- as_name(treat_var)
 
     denoms_df <- denoms_df_n %>%
-      left_join(denoms_df_dist, by = by_join) %>%
       complete(!!!layer_params[param_apears],
-               fill = list(n = 0, distinct_n = 0))
+               fill = list(n = 0)) %>%
+      left_join(denoms_df_dist, by = by_join)
 
     if (as_name(target_var[[1]]) %in% names(target)) {
       denoms_df <- denoms_df %>%

--- a/R/denom.R
+++ b/R/denom.R
@@ -159,14 +159,13 @@ get_denom_total <- function(.data, denoms_by, denoms_df,
 
   sums <-  denoms_df %>%
     filter(!!!filter_logic) %>%
-    group_by(!!!vars_in_denoms) %>%
-    extract(total_extract)
+    group_by(!!!vars_in_denoms)
 
-  if (total_extract == "n") {
-    .data$total <- ifelse(nrow(sums) > 0, sum(sums, na.rm = TRUE), 0)
-  } else {
-    .data$distinct_total <- ifelse(nrow(sums) > 0, sum(sums, na.rm = TRUE), 0)
-  }
+    .data$total <- ifelse(nrow(sums) > 0, sum(sums[["n"]], na.rm = TRUE), 0)
+    # distinct_n is present for all count layers, but not shift layers, so
+    # dont' do this for shift layers
+    if ("distinct_n" %in% names(sums))
+      .data$distinct_total <- ifelse(nrow(sums) > 0, sums[["distinct_n"]], 0)
 
   .data
 

--- a/R/nested.R
+++ b/R/nested.R
@@ -27,6 +27,10 @@ process_nested_count_target <- function(x) {
               immediate. = TRUE)
     }
 
+    if (isTRUE(include_total_row)) {
+      abort("You can't include total rows in nested counts. Instead, add a seperate layer for total counts.")
+    }
+
     if (!is.null(denoms_by)) {
       change_denom_ind <- map_chr(denoms_by, as_name) %in% "summary_var"
       second_denoms_by <- denoms_by

--- a/R/nested.R
+++ b/R/nested.R
@@ -5,8 +5,6 @@ process_nested_count_target <- function(x) {
 
     if(is.null(indentation)) indentation <- "   "
 
-
-
     assert_that(quo_is_symbol(target_var[[2]]),
                 msg = "Inner layers must be data driven variables")
 

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -287,9 +287,9 @@
       # A tibble: 3 x 6
         row_label1 var1_3            var1_4            var1_5          ord_l~1 ord_l~2
         <chr>      <chr>             <chr>             <chr>             <int>   <dbl>
-      1 4          "  1   3   1  15" "  2   4   8  12" "  1   3   2  ~       1       1
-      2 6          "  1   3   2  15" "  2   4   4  12" "  1   3   1  ~       1       2
-      3 8          "  1   3  12  15" "  0   4   0  12" "  1   3   2  ~       1       3
+      1 4          "  1   1   1  15" "  2   2   8  12" "  1   1   2  ~       1       1
+      2 6          "  1   1   2  15" "  2   2   4  12" "  1   1   1  ~       1       2
+      3 8          "  1   1  12  15" "  0   2   0  12" "  1   1   2  ~       1       3
       # ... with abbreviated variable names 1: ord_layer_index, 2: ord_layer_1
 
 # denoms with distinct population data populates as expected

--- a/tests/testthat/_snaps/count.md
+++ b/tests/testthat/_snaps/count.md
@@ -225,19 +225,18 @@
     Code
       build(t7)
     Output
-      # A tibble: 10 x 8
-         row_label1            row_l~1 var1_~2 var1_~3 var1_~4 ord_l~5 ord_l~6 ord_l~7
-         <chr>                 <chr>   <chr>   <chr>   <chr>     <int>   <dbl>   <dbl>
-       1 GASTROINTESTINAL DIS~ "GASTR~ " 6 ( ~ " 6 ( ~ " 3 ( ~       1       1     Inf
-       2 GASTROINTESTINAL DIS~ "   DI~ " 3 ( ~ " 1 ( ~ " 2 ( ~       1       1       1
-       3 GENERAL DISORDERS AN~ "GENER~ "11 ( ~ "21 ( ~ "21 ( ~       1       2     Inf
-       4 GENERAL DISORDERS AN~ "   AP~ " 4 ( ~ " 7 ( ~ " 5 ( ~       1       2       1
-       5 INFECTIONS AND INFES~ "INFEC~ " 5 ( ~ " 4 ( ~ " 3 ( ~       1       3     Inf
-       6 INFECTIONS AND INFES~ "   UP~ " 4 ( ~ " 1 ( ~ " 1 ( ~       1       3       1
-       7 SKIN AND SUBCUTANEOU~ "SKIN ~ " 7 ( ~ "21 ( ~ "26 ( ~       1       4     Inf
-       8 SKIN AND SUBCUTANEOU~ "   ER~ " 4 ( ~ " 3 ( ~ " 2 ( ~       1       4       1
-       9 SKIN AND SUBCUTANEOU~ "   PR~ " 3 ( ~ " 8 ( ~ " 7 ( ~       1       4       2
-      10 Total                 "Total" "47 (1~ "77 (1~ "76 (1~       1       5     Inf
+      # A tibble: 9 x 8
+        row_label1             row_l~1 var1_~2 var1_~3 var1_~4 ord_l~5 ord_l~6 ord_l~7
+        <chr>                  <chr>   <chr>   <chr>   <chr>     <int>   <dbl>   <dbl>
+      1 GASTROINTESTINAL DISO~ "GASTR~ " 6 ( ~ " 6 ( ~ " 3 ( ~       1       1     Inf
+      2 GASTROINTESTINAL DISO~ "   DI~ " 3 ( ~ " 1 ( ~ " 2 ( ~       1       1       1
+      3 GENERAL DISORDERS AND~ "GENER~ "11 ( ~ "21 ( ~ "21 ( ~       1       2     Inf
+      4 GENERAL DISORDERS AND~ "   AP~ " 4 ( ~ " 7 ( ~ " 5 ( ~       1       2       1
+      5 INFECTIONS AND INFEST~ "INFEC~ " 5 ( ~ " 4 ( ~ " 3 ( ~       1       3     Inf
+      6 INFECTIONS AND INFEST~ "   UP~ " 4 ( ~ " 1 ( ~ " 1 ( ~       1       3       1
+      7 SKIN AND SUBCUTANEOUS~ "SKIN ~ " 7 ( ~ "21 ( ~ "26 ( ~       1       4     Inf
+      8 SKIN AND SUBCUTANEOUS~ "   ER~ " 4 ( ~ " 3 ( ~ " 2 ( ~       1       4       1
+      9 SKIN AND SUBCUTANEOUS~ "   PR~ " 3 ( ~ " 8 ( ~ " 7 ( ~       1       4       2
       # ... with abbreviated variable names 1: row_label2, 2: var1_Placebo,
       #   3: `var1_Xanomeline High Dose`, 4: `var1_Xanomeline Low Dose`,
       #   5: ord_layer_index, 6: ord_layer_1, 7: ord_layer_2
@@ -247,19 +246,18 @@
     Code
       build(t8)
     Output
-      # A tibble: 10 x 8
-         row_label1            row_l~1 var1_~2 var1_~3 var1_~4 ord_l~5 ord_l~6 ord_l~7
-         <chr>                 <chr>   <chr>   <chr>   <chr>     <int>   <dbl>   <dbl>
-       1 GASTROINTESTINAL DIS~ "GASTR~ " 6 ( ~ " 6 ( ~ " 3 ( ~       1       3     Inf
-       2 GASTROINTESTINAL DIS~ "   DI~ " 3 ( ~ " 1 ( ~ " 2 ( ~       1       3       2
-       3 GENERAL DISORDERS AN~ "GENER~ "11 ( ~ "21 ( ~ "21 ( ~       1      21     Inf
-       4 GENERAL DISORDERS AN~ "   AP~ " 4 ( ~ " 7 ( ~ " 5 ( ~       1      21       5
-       5 INFECTIONS AND INFES~ "INFEC~ " 5 ( ~ " 4 ( ~ " 3 ( ~       1       3     Inf
-       6 INFECTIONS AND INFES~ "   UP~ " 4 ( ~ " 1 ( ~ " 1 ( ~       1       3       1
-       7 SKIN AND SUBCUTANEOU~ "SKIN ~ " 7 ( ~ "21 ( ~ "26 ( ~       1      26     Inf
-       8 SKIN AND SUBCUTANEOU~ "   ER~ " 4 ( ~ " 3 ( ~ " 2 ( ~       1      26       2
-       9 SKIN AND SUBCUTANEOU~ "   PR~ " 3 ( ~ " 8 ( ~ " 7 ( ~       1      26       7
-      10 Total                 "Total" "47 (1~ "77 (1~ "76 (1~       1      76     Inf
+      # A tibble: 9 x 8
+        row_label1             row_l~1 var1_~2 var1_~3 var1_~4 ord_l~5 ord_l~6 ord_l~7
+        <chr>                  <chr>   <chr>   <chr>   <chr>     <int>   <dbl>   <dbl>
+      1 GASTROINTESTINAL DISO~ "GASTR~ " 6 ( ~ " 6 ( ~ " 3 ( ~       1       3     Inf
+      2 GASTROINTESTINAL DISO~ "   DI~ " 3 ( ~ " 1 ( ~ " 2 ( ~       1       3       2
+      3 GENERAL DISORDERS AND~ "GENER~ "11 ( ~ "21 ( ~ "21 ( ~       1      21     Inf
+      4 GENERAL DISORDERS AND~ "   AP~ " 4 ( ~ " 7 ( ~ " 5 ( ~       1      21       5
+      5 INFECTIONS AND INFEST~ "INFEC~ " 5 ( ~ " 4 ( ~ " 3 ( ~       1       3     Inf
+      6 INFECTIONS AND INFEST~ "   UP~ " 4 ( ~ " 1 ( ~ " 1 ( ~       1       3       1
+      7 SKIN AND SUBCUTANEOUS~ "SKIN ~ " 7 ( ~ "21 ( ~ "26 ( ~       1      26     Inf
+      8 SKIN AND SUBCUTANEOUS~ "   ER~ " 4 ( ~ " 3 ( ~ " 2 ( ~       1      26       2
+      9 SKIN AND SUBCUTANEOUS~ "   PR~ " 3 ( ~ " 8 ( ~ " 7 ( ~       1      26       7
       # ... with abbreviated variable names 1: row_label2, 2: var1_Placebo,
       #   3: `var1_Xanomeline High Dose`, 4: `var1_Xanomeline Low Dose`,
       #   5: ord_layer_index, 6: ord_layer_1, 7: ord_layer_2
@@ -304,4 +302,8 @@
       # ... with abbreviated variable names 1: var1_Placebo, 2: var1_Total,
       #   3: `var1_Xanomeline High Dose`, 4: `var1_Xanomeline Low Dose`,
       #   5: ord_layer_index, 6: ord_layer_1
+
+# nested count layers error out when you try to add a total row
+
+    You can't include total rows in nested counts. Instead, add a seperate layer for total counts.
 

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -782,8 +782,7 @@ test_that("set_numeric_threshold works as expected", {
     tplyr_table(TRTA) %>%
     add_layer(
       group_count(vars(AEBODSYS, AEDECOD)) %>%
-        set_numeric_threshold(3, "n", "Placebo") %>%
-        add_total_row()
+        set_numeric_threshold(3, "n", "Placebo")
     )
 
   expect_snapshot(build(t7))
@@ -793,7 +792,6 @@ test_that("set_numeric_threshold works as expected", {
     add_layer(
       group_count(vars(AEBODSYS, AEDECOD)) %>%
         set_numeric_threshold(3, "n", "Placebo") %>%
-        add_total_row() %>%
         set_order_count_method("bycount")
     )
 
@@ -841,4 +839,16 @@ test_that("denoms with distinct population data populates as expected", {
     build()
 
   expect_snapshot(tab)
+})
+
+test_that("nested count layers error out when you try to add a total row", {
+
+  # GH issue 92
+  tab <- tplyr_table(mtcars, am) %>%
+    add_layer(
+      group_count(vars(cyl, grp)) %>%
+        add_total_row()
+    )
+
+    expect_snapshot_error(build(tab))
 })


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] All new and existing tests passed.

This PR closes #80.

There were a couple of changes in `get_denom_total`, but the actual issue was in `process_count_denoms`. The fix was to reorder the `complete` and the `left_join`. What would happen is the distinct denoms would get calculated correctly, but then the complete would come by and turn all the distinct denoms to 0, by reordering them it fixes the issue.

I think the test that changed below was actually incorrect so we had a test for it but didn't notice that it wasn't calculating correctly.