### PR TITLE
Gh issue 124

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -302,8 +302,8 @@ clean_attr <- function(dat) {
 
 #' Simulate IBM rounding
 #'
-#' This logic is from the github issue
-#' https://github.com/atorus-research/Tplyr/issues/9
+#' This logic is from the stackoverflow issue
+#' https://stackoverflow.com/questions/12688717/round-up-from-5
 #'
 #' @param x The numeric values to round
 #' @param n The number of decimal rounding points
@@ -314,10 +314,13 @@ ut_round <- function(x, n=0)
 {
   # x is the value to be rounded
   # n is the precision of the rounding
-  scale <- 10^n
-  y <- trunc(x * scale + sign(x) * 0.5) / scale
+  posneg <- sign(x)                                         
+  e <- abs(x) * 10^n                                  
+  e <- e + 0.5 + sqrt(.Machine$double.eps)
+  e <- trunc(e)
+  e <- e / 10^n
   # Return the rounded number
-  return(y)
+  return(e * posneg)
 }
 
 #' Assign a row identifier to a layer

--- a/tests/testthat/test-count.R
+++ b/tests/testthat/test-count.R
@@ -675,6 +675,19 @@ test_that("test IBM rounding option", {
   options(tplyr.IBMRounding = FALSE)
 })
 
+test_that("test specific rounding proplem #124", {
+  vec <- c(2.64, -3.20, -2.88, 2.95)
+  mvec <- mean(vec)
+
+  options(tplyr.IBMRounding = TRUE)
+
+  rounded <- ut_round(mvec, 3)
+
+  expect_equal(rounded, -0.123)
+
+  options(tplyr.IBMRounding = FALSE)
+})
+
 test_that("nested count layers will error out if second variable is bigger than the first", {
   mtcars <- mtcars2
   mtcars$grp <- paste0("grp.", as.numeric(mtcars$cyl) + rep(c(0, 0.5), 16))


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Fix for issue #124.

Count the same mean from the issue:
```r
> vec <- c(2.64, -3.20, -2.88, 2.95)

> mvec <- mean(vec)

> mvec
[1] -0.1225
``` 

Under the hood R stores numbers not the same way as displays them. That can be seen using the `sprintf()` function.
Display 20 decimals using `sprintf()`:
```r
> sprintf("%.20f", mvec)
[1] "-0.12249999999999994227"
```

So, looking at that result, the current `ut_round()` function does things correctly, but that is not the result that we expect.

The following links provide explanations and a function that outputs correct results:
- [https://stackoverflow.com/questions/12688717/round-up-from-5](url)
- [http://andrewlandgraf.com/2012/06/15/rounding-in-r/](url)

```r
ut_round_new <- function(x, n=0)
{
  # x is the value to be rounded
  # n is the precision of the rounding
  posneg <- sign(x)                                         
  e <- abs(x) * 10^n                                  
  e <- e + 0.5 + sqrt(.Machine$double.eps)
  e <- trunc(e)
  e <- e / 10^n
  # Return the rounded number
  return(e * posneg)
}

> vec <- c(2.64, -3.20, -2.88, 2.95)

> mvec <- mean(vec)

> mvec
[1] -0.1225

> ut_round_new(mvec, 3)
[1] -0.123
```