### PR TITLE
Have R CMD check run on PRs & pushed to devel

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
       - master
+      - devel
   pull_request:
     branches:
       - main
       - master
+      - devel
 
 name: R-CMD-check
 


### PR DESCRIPTION
Updates R CMD check action to run on PRs and pushes to branch `devel` in addition to `main`.

I left the other 2 workflows as is (`pkgdown` and code coverage) because it's probably better if they reflect the more stable `main` vs. the potentially unstable `devel`.
