### PR TITLE
Resolve #215: honor an unnamed `empty` on all-missing desc rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: Tplyr
 Title: A Traceability Focused Grammar of Clinical Data Summary
-Version: 1.4.0
+Version: 1.4.1
 Authors@R: 
     c(
     person(given = "Eli",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Tplyr 1.4.1
+
+## Bug fixes
+- Resolve #215 Fix an unnamed `empty` in `f_str()` being ignored for descriptive statistics rows where every value is missing, which left the cell blank instead of filling the format string. This was a regression introduced in 1.3.2
+
 # Tplyr 1.4.0
 
 ## New Features

--- a/R/desc.R
+++ b/R/desc.R
@@ -325,13 +325,19 @@ construct_desc_string_vec <- function(data, format_strings, max_prec = c(int = I
       }
     }
 
-    # Handle rows where all values are NA
+    # Rows where every value is NA are only short-circuited when `empty` is
+    # named '.overall', which replaces the whole result. An unnamed `empty`
+    # fills within the format string instead, so those rows carry on to the
+    # normal formatting path where num_fmt_vec_auto() pads each value.
     if (any(all_na_mask) && '.overall' %in% names(fmt$empty)) {
       result[idx[all_na_mask]] <- fmt$empty['.overall']
+      keep_mask <- !all_na_mask
+    } else {
+      keep_mask <- rep(TRUE, length(idx))
     }
 
-    # Process non-all-NA rows
-    non_na_idx <- idx[!all_na_mask]
+    # Process the rows that still need formatting
+    non_na_idx <- idx[keep_mask]
 
     if (length(non_na_idx) == 0) next
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,16 +1,12 @@
-## Submission 1.4.0
+## Submission 1.4.1
 
-This is a minor release (current CRAN version 1.3.3). It adds one backwards
-compatible feature and fixes two bugs:
+This is a patch release (current CRAN version 1.4.0). It fixes a single bug,
+with no user-facing API change:
 
-* New `max_int` and `max_dec` arguments to `set_format_strings()`, along with a
-  corresponding `tplyr.max_precision` option, allowing an overall maximum
-  precision to be applied after auto-precision and any '+' modifier are
-  resolved (#219). The defaults reproduce the previous behaviour exactly.
-* Fix table level defaults from `set_shift_layer_formats()` being silently
-  ignored by shift layers that do not set their own format strings (#216).
-* Fix incorrect `add_missing_subjects_row()` counts on nested count layers,
-  where `set_distinct_by()` was not applied to the inner layer (#217).
+* Fix an unnamed `empty` value in `f_str()` being ignored for descriptive
+  statistics rows where every summarized value is missing, which left the cell
+  blank instead of filling the format string (#215). This was a regression
+  introduced in 1.3.2.
 
 ## Test Environments
 
@@ -18,7 +14,8 @@ compatible feature and fixes two bugs:
 * GitHub Actions:
   * windows-latest (R release)
   * macOS-latest (R release)
-  * ubuntu-latest and ubuntu-22.04 (R release and R devel)
+  * ubuntu-latest and ubuntu-22.04 (R release)
+  * ubuntu-latest (R devel)
 
 ## R CMD check results
 
@@ -27,6 +24,6 @@ compatible feature and fixes two bugs:
 ## Reverse dependencies
 
 Tplyr has no strong reverse dependencies (Depends/Imports/LinkingTo). Two
-packages list it under Suggests (clinify, logrx); the new arguments and option
-are additive with defaults that preserve existing output, so they are
-unaffected.
+packages list it under Suggests (clinify, logrx); this patch restores
+previously documented formatting behaviour and makes no API change, so they
+are unaffected.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -14,8 +14,7 @@ with no user-facing API change:
 * GitHub Actions:
   * windows-latest (R release)
   * macOS-latest (R release)
-  * ubuntu-latest and ubuntu-22.04 (R release)
-  * ubuntu-latest (R devel)
+  * ubuntu-latest and ubuntu-22.04 (R release and R devel)
 
 ## R CMD check results
 

--- a/tests/testthat/test-desc.R
+++ b/tests/testthat/test-desc.R
@@ -162,3 +162,48 @@ test_that("Infinites aren't produced from min/max", {
 
   expect_equal(x$var1_b, "")
 })
+
+
+test_that("An unnamed `empty` fills within the format string when every value is NA", {
+
+  # Drop a whole PARAMCD/treatment cell so the resulting row is entirely NA
+  d <- tplyr_adlb %>%
+    filter(PARAMCD %in% c("CK", "URATE")) %>%
+    filter(!(PARAMCD == "CK" & TRTA == "Placebo"))
+
+  build_empty <- function(...) {
+    t <- tplyr_table(d, TRTA) %>%
+      add_layer(
+        group_desc(AVAL, by = PARAMCD) %>%
+          set_format_strings(...)
+      )
+    build(t)$var1_Placebo[1:2]
+  }
+
+  # Unnamed empty pads within the format string rather than blanking the cell
+  expect_equal(
+    build_empty(
+      "n"        = f_str("xxx", n, empty = "0"),
+      "mean, sd" = f_str("xxx.xx, xxx.xx", mean, sd, empty = "NA")
+    ),
+    c("  0", "    NA,     NA")
+  )
+
+  # A '.overall' empty still replaces the whole result
+  expect_equal(
+    build_empty(
+      "n"        = f_str("xxx", n, empty = c(.overall = "NONE")),
+      "mean, sd" = f_str("xxx.xx, xxx.xx", mean, sd, empty = c(.overall = "NONE"))
+    ),
+    c("NONE", "NONE")
+  )
+
+  # The default empty leaves the cell blank
+  expect_equal(
+    build_empty(
+      "n"        = f_str("xxx", n),
+      "mean, sd" = f_str("xxx.xx, xxx.xx", mean, sd)
+    ),
+    c("", "")
+  )
+})


### PR DESCRIPTION
Fixes #215.

A regression introduced by the 1.3.2 vectorization of descriptive string construction.

## Problem

An unnamed `empty` in `f_str()` is documented to fill *within* the format string, padded to the same width as the numbers. It was instead being ignored whenever every value on a row was missing, leaving the cell blank.

```r
group_desc(AVAL, by = PARAMCD) %>%
  set_format_strings(
    'n'        = f_str('xxx', n, empty = "0"),
    'mean, sd' = f_str('xxx.xx, xxx.xx', mean, sd, empty = "NA")
  )
```

| PARAMCD | row | before | after |
|---|---|---|---|
| CK | `n` | `` (blank) | `  0` |
| CK | `mean, sd` | `` (blank) | `    NA,     NA` |

## Cause

`construct_desc_string_vec()` (`R/desc.R:328`) dropped all-NA rows from the formatting set unconditionally, but only populated them when `empty` was named `.overall`:

```r
if (any(all_na_mask) && '.overall' %in% names(fmt$empty)) {
  result[idx[all_na_mask]] <- fmt$empty['.overall']
}
non_na_idx <- idx[!all_na_mask]   # all-NA rows removed either way
if (length(non_na_idx) == 0) next
```

With an unnamed `empty` neither branch applied and the cell stayed `""`.

The scalar `construct_desc_string()` that this replaced in 1.3.2 only returned early for `.overall`, otherwise **falling through** to the normal formatting path where `num_fmt()` pads `empty` to width. That's why the reporter says it used to work.

## Fix

Keep the all-NA rows in the formatting set unless `.overall` already handled them. `num_fmt_vec_auto()` needed no change — it already pads `fmt$empty[1]` to width for NA values, which is how partially missing rows have always worked.

## Behaviour across all three `empty` modes

| `empty` | result |
|---|---|
| default `c(.overall = '')` | `""` — unchanged |
| unnamed, e.g. `"0"` / `"NA"` | padded within the format string — **fixed** |
| named `c(.overall = "NONE")` | `"NONE"` — unchanged |

Verified with fixed and auto-precision (`a.a+1`) format strings.

## Testing

- New regression test in `test-desc.R` covering all three modes. Confirmed it **fails** with the fix reverted and passes with it.
- Full suite: 978 passing, no other test changed behaviour.
- `devtools::check(args = c("--no-manual", "--as-cran"))` on macOS aarch64, R 4.5.1: 0 errors, 0 warnings, 0 notes.

## Version

Staged as **1.4.1**. 1.4.0 is currently in CRAN's queue — this should go out after that clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
